### PR TITLE
Add pxt-ml-extension-poc as bundledirs

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -17,6 +17,7 @@ npm install -g pxt
 npm link ../pxt
 
 # Add ml extension
+node -e "const f = 'pxtarget.json'; const data = fs.readFileSync(f, 'utf8'); fs.writeFileSync(f, data.replace('\"libs/core\",', '\"libs/core\",\"libs/pxt-ml-extension-poc\",'))"
 cd libs
 git clone -b v0.1.23 git@github.com:microbit-foundation/pxt-ml-extension-poc.git
 cd pxt-ml-extension-poc

--- a/ci.sh
+++ b/ci.sh
@@ -15,4 +15,14 @@ npm install -g pxt
 )
 
 npm link ../pxt
+
+# Add ml extension
+cd libs
+git clone -b v0.1.23 git@github.com:microbit-foundation/pxt-ml-extension-poc.git
+cd pxt-ml-extension-poc
+node -e "const f = 'pxt.json'; const data = fs.readFileSync(f, 'utf8'); fs.writeFileSync(f, data.replace('*', 'file:../core'))"
+pxt install
+pxt build
+cd ../..
+
 pxt staticpkg

--- a/ci.sh
+++ b/ci.sh
@@ -17,13 +17,13 @@ npm install -g pxt
 npm link ../pxt
 
 # Add ml extension
-node -e "const f = 'pxtarget.json'; const data = fs.readFileSync(f, 'utf8'); fs.writeFileSync(f, data.replace('\"libs/core\",', '\"libs/core\",\"libs/pxt-ml-extension-poc\",'))"
+node -e "const f = 'pxtarget.json'; const data = fs.readFileSync(f, 'utf8'); fs.writeFileSync(f, data.replace('\"libs/core\",', '\"libs/core\",\"libs/machine-learning-poc\",'))"
 cd libs
 git clone -b v0.1.23 git@github.com:microbit-foundation/pxt-ml-extension-poc.git
-cd pxt-ml-extension-poc
-node -e "const f = 'pxt.json'; const data = fs.readFileSync(f, 'utf8'); fs.writeFileSync(f, data.replace('*', 'file:../core'))"
+mv pxt-ml-extension-poc machine-learning-poc
+cd machine-learning-poc
+node -e "const f = 'pxt.json'; const data = fs.readFileSync(f, 'utf8'); fs.writeFileSync(f, data.replace('*', 'file:../core').replace('Machine Learning POC', 'machine-learning-poc'))"
 pxt install
-pxt build
 cd ../..
 
 pxt staticpkg

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -7,6 +7,7 @@
   "corepkg": "core",
   "bundleddirs": [
     "libs/core",
+    "libs/machine-learning-poc",
     "libs/radio",
     "libs/devices",
     "libs/bluetooth",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -7,7 +7,6 @@
   "corepkg": "core",
   "bundleddirs": [
     "libs/core",
-    "libs/machine-learning-poc",
     "libs/radio",
     "libs/devices",
     "libs/bluetooth",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -244,7 +244,7 @@
     "partsAspectRatio": 0.69,
     "messageSimulators": {
       "machineLearningPoc": {
-        "url": "http://localhost:3000/simulator/?parentOrigin=$PARENT_ORIGIN$",
+        "url": "https://makecode-ml-editor-extension-poc.pages.dev/simulator/?parentOrigin=$PARENT_ORIGIN$",
         "localHostUrl": "http://localhost:3000/simulator/?parentOrigin=$PARENT_ORIGIN$",
         "aspectRatio": 4,
         "permanent": true

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -17,7 +17,8 @@
     "libs/flashlog",
     "libs/datalogger",
     "libs/color",
-    "libs/audio-recording"
+    "libs/audio-recording",
+    "libs/pxt-ml-extension-poc"
   ],
   "cloud": {
     "workspace": false,

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -17,8 +17,7 @@
     "libs/flashlog",
     "libs/datalogger",
     "libs/color",
-    "libs/audio-recording",
-    "libs/pxt-ml-extension-poc"
+    "libs/audio-recording"
   ],
   "cloud": {
     "workspace": false,


### PR DESCRIPTION
**To test locally**
```
$ git clone git@github.com:microbit-matt-hillsdon/pxt-microbit.git
$ cd pxt-microbit
$ git checkout add-extension
$ ./ci.sh
$ npx serve built/packaged
```

Visit locally served MakeCode with `?nolocalhost=1` to test what it is like when deployed

**Non-ideal consequences**

- Because it is now a bundled package, the project code dependencies need to be updated to no longer use the github extension link: https://github.com/microbit-foundation/ml-trainer/pull/254/commits/3f35f0d775f276af6c8f4630be3ed2d807967979
- Downloaded hex cannot be used in regular MakeCode editor because it is not bundled in the regular MakeCode

**Branch preview**

https://add-extension.pxt-microbit.pages.dev/